### PR TITLE
Add: Added Auto Reply Bot for New Issues

### DIFF
--- a/.github/workflows/issue-auto-reply.yml
+++ b/.github/workflows/issue-auto-reply.yml
@@ -1,0 +1,26 @@
+name: Auto Reply to New Issues
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  add-auto-response:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Add Auto Response to new issues
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const message = `Thank you for raising this issue! Our team will review it soon.
+            
+            For more queries, discussions, or approval of requests, please join our Discord server: [Discord Link](https://discord.com/invite/Yn9g6KuWyA)`;
+            
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: message
+            });


### PR DESCRIPTION
### Summary:

- Created a GitHub Actions workflow `.github/workflows/issue-auto-reply.ym`l
- Workflow triggers on new issue creation `(issues: opened)`
- Posts a standardised welcome comment with a Discord server invite link

### Checklist

- [x]  Workflow file is created in correct location
- [x]  Workflow triggers only on new issues (not PRs)
- [x]  Tested and comment is posted automatically within seconds of issue creation
- [x]  Message includes Discord server link
- [x]  Proper permissions are set for the workflow`(issues: write)`

### Related Issue
Closes https://github.com/DhanushNehru/Ultimate-DevOps-Resources/issues/38